### PR TITLE
Add code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+*   @innovationnorway/terraform


### PR DESCRIPTION
Makes `innovationnorway/terraform` team the default owners for everything in the repo.